### PR TITLE
Correcion en la pestaña de materias

### DIFF
--- a/tp4_VillagranEnzoMauricio/src/main/java/ar/edu/unju/fi/controller/MateriaController.java
+++ b/tp4_VillagranEnzoMauricio/src/main/java/ar/edu/unju/fi/controller/MateriaController.java
@@ -55,7 +55,7 @@ public class MateriaController {
 		model.addAttribute("edicion", edicion);
 		model.addAttribute("materia", materiaDTO);
 		model.addAttribute("hayDocentes", docenteService.size());
-		model.addAttribute("docentes", docenteService.findDocentesByEstadoTrue());
+		model.addAttribute("docentes", docenteService.docentesSinMaterias());
 		model.addAttribute("hayCarreras", carreraService.size());
 		model.addAttribute("carreras", carreraService.findCarrerasByEstadoTrue());
 		return("materia");
@@ -68,7 +68,7 @@ public class MateriaController {
 			modelAndView.addObject("edicion", false);
 			modelAndView.addObject("titulo", "Nueva Materia");
 			modelAndView.addObject("hayDocentes", docenteService.size());
-			modelAndView.addObject("docentes", docenteService.findDocentesByEstadoTrue());
+			modelAndView.addObject("docentes", docenteService.docentesSinMaterias());
 			modelAndView.addObject("hayCarreras", carreraService.size());
 			modelAndView.addObject("carreras", carreraService.findCarrerasByEstadoTrue());
 			return modelAndView;
@@ -100,7 +100,7 @@ public class MateriaController {
 		model.addAttribute("materia", materiaEncontrada);
 		model.addAttribute("titulo", "Modificar materia");
 		model.addAttribute("carreras",carreraService.findCarrerasByEstadoTrue());
-		model.addAttribute("docentes", docenteService.findDocentesByEstadoTrue());
+		model.addAttribute("docentes", docenteService.docentesSinMaterias());
 		return("materia");
 	}
 	@PostMapping("/modificar")
@@ -109,7 +109,7 @@ public class MateriaController {
 	 	       model.addAttribute("edicion", true);
 	 	       model.addAttribute("titulo", "Modificar materia");
 	 	       model.addAttribute("hayDocentes", docenteService.size());
-	 	       model.addAttribute("docentes", docenteService.findDocentesByEstadoTrue());
+	 	       model.addAttribute("docentes", docenteService.docentesSinMaterias());
 	 	       model.addAttribute("hayCarreras", carreraService.size());
 	 	       model.addAttribute("carreras", carreraService.findCarrerasByEstadoTrue());
 	 	       return("materia");

--- a/tp4_VillagranEnzoMauricio/src/main/java/ar/edu/unju/fi/repository/DocenteRepository.java
+++ b/tp4_VillagranEnzoMauricio/src/main/java/ar/edu/unju/fi/repository/DocenteRepository.java
@@ -10,4 +10,5 @@ import ar.edu.unju.fi.model.Docente;
 @Repository
 public interface DocenteRepository extends JpaRepository<Docente,Integer>{
 	List<Docente> findByEstadoTrue();
+	
 }

--- a/tp4_VillagranEnzoMauricio/src/main/java/ar/edu/unju/fi/service/IDocenteService.java
+++ b/tp4_VillagranEnzoMauricio/src/main/java/ar/edu/unju/fi/service/IDocenteService.java
@@ -9,6 +9,8 @@ public interface IDocenteService {
 	
 	List<DocenteDTO> findDocentesByEstadoTrue();
 	
+	List<DocenteDTO> docentesSinMaterias();
+	
 	DocenteDTO findByLegajo(int legajo);
 	
 	DocenteDTO save(DocenteDTO docenteDTO);

--- a/tp4_VillagranEnzoMauricio/src/main/java/ar/edu/unju/fi/service/IMateriaService.java
+++ b/tp4_VillagranEnzoMauricio/src/main/java/ar/edu/unju/fi/service/IMateriaService.java
@@ -11,4 +11,5 @@ public interface IMateriaService {
 	void deleteByCod(int codigo);
 	void edit(MateriaDTO materiaDTO) throws Exception;
 	List<MateriaDTO> findMateriasByEstadoTrue();
+	
 }

--- a/tp4_VillagranEnzoMauricio/src/main/java/ar/edu/unju/fi/service/imp/DocenteServiceImpl.java
+++ b/tp4_VillagranEnzoMauricio/src/main/java/ar/edu/unju/fi/service/imp/DocenteServiceImpl.java
@@ -1,5 +1,6 @@
 package ar.edu.unju.fi.service.imp;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.commons.logging.Log;
@@ -10,7 +11,9 @@ import org.springframework.stereotype.Service;
 import ar.edu.unju.fi.dto.DocenteDTO;
 import ar.edu.unju.fi.mapper.DocenteMapper;
 import ar.edu.unju.fi.model.Docente;
+import ar.edu.unju.fi.model.Materia;
 import ar.edu.unju.fi.repository.DocenteRepository;
+import ar.edu.unju.fi.repository.MateriaRepository;
 import ar.edu.unju.fi.service.IDocenteService;
 
 @Service
@@ -21,7 +24,8 @@ public class DocenteServiceImpl implements IDocenteService {
 	
 	@Autowired
 	private DocenteRepository docenteRepository;
-	
+	@Autowired
+	private MateriaRepository materiaRepository; 
 
 	@Override
 	public List<DocenteDTO> findDocentesByEstadoTrue() {
@@ -79,6 +83,25 @@ public class DocenteServiceImpl implements IDocenteService {
 		LOGGER.info("METHOD:  size()");
 		LOGGER.info("RESULT: cuenta las entidades del repositorio");
 		return (int) docenteRepository.count();
+	}
+	@Override
+	public List<DocenteDTO> docentesSinMaterias() {
+		LOGGER.info("SERVICE: IDocenteService -> DocenteServiceImpl");
+		LOGGER.info("METHOD:  docentesSinMaterias()");
+		LOGGER.info("RESULT: lista de docentes DTO que no tienen una materia asignada y su estado activo");
+		List<Materia> materiasActivas = materiaRepository.findByEstadoTrue();
+		List<Docente> docentesActivos = docenteRepository.findByEstadoTrue();
+		List<Integer> legajosDeDocentesMaterias = new ArrayList<>();
+		List<Docente> docenteSinMateria = new ArrayList<>();
+		for(Materia materia : materiasActivas) {
+			legajosDeDocentesMaterias.add(materia.getDocente().getLegajo());
+		}
+		for(Docente docente : docentesActivos) {
+			if(!legajosDeDocentesMaterias.contains(docente.getLegajo())) {
+				docenteSinMateria.add(docente);
+			}
+		}
+		return docenteMapper.toDocenteDTOList(docenteSinMateria);
 	}
 
 	


### PR DESCRIPTION
Se realizo la correcion de materias, a la hora de crear una nueva, solo apareceran los docentes activos y que no tengan una materia asignada